### PR TITLE
Updated footer year to 2024

### DIFF
--- a/paras/src/App.js
+++ b/paras/src/App.js
@@ -222,7 +222,7 @@ const App = () => {
       </div>
 
       <footer className="footer">
-        <p>&copy; 2023 TIC TAC TOE. All rights reserved.</p>
+        <p>&copy; 2024 TIC TAC TOE. All rights reserved.</p>
       </footer>
 
       <Sparkle x={mousePosition.x} y={mousePosition.y} />


### PR DESCRIPTION
The footer year in the website was previously set to 2023. This update changes the year to 2024, ensuring that the footer accurately reflects the current year. 